### PR TITLE
Address derivation from seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ name = "backtrace-sys"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -277,7 +277,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.37.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -890,7 +890,7 @@ name = "libloading"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1012,7 +1012,7 @@ name = "miniz-sys"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1029,7 +1029,7 @@ name = "miniz_oxide_c_api"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1110,7 +1110,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1274,7 +1274,7 @@ name = "openssl-sys"
 version = "0.9.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1599,7 +1599,7 @@ name = "ring"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2434,7 +2434,7 @@ dependencies = [
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
-"checksum cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02"
+"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,25 +149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,11 +156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byte-tools"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -387,14 +363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "dirs"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,14 +492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "generic-array"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1297,11 +1257,6 @@ version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "opaque-debug"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "openssl"
 version = "0.10.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,16 +1705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,17 +1776,6 @@ dependencies = [
  "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2329,15 +2263,16 @@ dependencies = [
  "grin_store 0.5.1 (git+https://github.com/mimblewimble/grin)",
  "grin_util 0.5.1 (git+https://github.com/mimblewimble/grin)",
  "grin_wallet 0.5.1 (git+https://github.com/mimblewimble/grin)",
+ "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ripemd160 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2495,11 +2430,8 @@ dependencies = [
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
-"checksum block-buffer 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49665c62e0e700857531fa5d3763e91b539ff1abeebd56808d378b495870d60d"
-"checksum block-padding 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc4358306e344bf9775d0197fd00d2603e5afb0771bb353538630f022068ea3"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
-"checksum byte-tools 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "980479e6fde23246dfb54d47580d66b4e99202e7579c5eaa9fe10ecb5ebd2182"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02"
@@ -2524,7 +2456,6 @@ dependencies = [
 "checksum csv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ef22b37c7a51c564a365892c012dc0271221fdcc64c69b19ba4d6fa8bd96d9c"
 "checksum ct-logs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "95a4bf5107667e12bf6ce31a3a5066d67acc88942b6742117a41198734aaccaa"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
@@ -2542,7 +2473,6 @@ dependencies = [
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum grin_api 0.5.1 (git+https://github.com/mimblewimble/grin)" = "<none>"
@@ -2611,7 +2541,6 @@ dependencies = [
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
 "checksum odds 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
-"checksum opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "51ecbcb821e1bd256d456fe858aaa7f380b63863eab2eb86eee1bd9f33dd6682"
 "checksum openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9"
 "checksum openssl-sys 0.9.40 (registry+https://github.com/rust-lang/crates.io-index)" = "1bb974e77de925ef426b6bc82fce15fd45bdcbeb5728bffcfc7cdeeb7ce1c2d6"
 "checksum ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0015e9e8e28ee20c581cfbfe47c650cedeb9ed0721090e0b7ebb10b9cdbcc2"
@@ -2663,7 +2592,6 @@ dependencies = [
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum sct 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb8f61f9e6eadd062a71c380043d28036304a4706b3c4dd001ff3387ed00745a"
-"checksum secp256k1 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)" = "77b934e699801fc7c0462755340c7b8c00f9d2e324ce2c30fb4c6ca9d2b3a745"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)" = "0e732ed5a5592c17d961555e3b552985baf98d50ce418b7b655f31f6ba7eb1b7"
@@ -2673,7 +2601,6 @@ dependencies = [
 "checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
-"checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,16 @@ ws = { version="0.7", features=["ssl"] }
 dirs = "1"
 futures = "0.1"
 tokio = "= 0.1.11"
-rand = "0.4"
-secp256k1 = { version="0.11", features=["rand"] }
-sha2 = "0.8.0"
+rand = "0.5"
+sha2 = "0.7"
 digest = "0.7"
 lmdb-zero = "0.4"
 failure = "0.1"
 uuid = { version = "0.6", features = ["serde", "v4"] }
 regex = "1"
 rustyline = "3.0"
+hmac = "0.6"
+ripemd160 = "0.7"
 
 grin_core = { git = "https://github.com/mimblewimble/grin" }
 grin_wallet = { git = "https://github.com/mimblewimble/grin" }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ While running, wallet713 works with an internal command prompt. You type command
     + [Restoring a wallet using your mnemonic BIP-39 phrase](#restoring-a-wallet-using-your-mnemonic-bip-39-phrase)
     + [Manually importing a .seed](#manually-importing-a-seed)
 - [Supported address formats](#supported-address-formats)
-  * [713.grinbox](#713grinbox)
+  * [Grinbox](#grinbox)
   * [Keybase](#keybase)
 - [Command documentation](#command-documentation)
 
@@ -26,7 +26,7 @@ While running, wallet713 works with an internal command prompt. You type command
 
 ### Getting started
 
-When you run the wallet for the first time, the wallet will create a config file for you and also generate your public/private keypairs which you need to use your 713.grinbox address. Running `config` displays your current configuration.
+When you run the wallet for the first time, the wallet will create a config file for you. Running `config` displays your current configuration.
 Configuration files will be created by default under ~/.wallet713/ under a dedicated folder for each chain type (/main or /floo).
 
 Running against mainnet:
@@ -49,13 +49,13 @@ Display wallet info:
 wallet713> $ info
 ```
 
-In order to receive grins from others you need to listen for transactions coming to your 713.grinbox address:
+In order to receive grins from others you need to listen for transactions coming to your grinbox address:
 ```
 wallet713> $ listen
 ```
 This will also display your grinbox address.
 
-Standard 713.grinbox addressses always start with `x`. 
+Standard floonet grinbox addressses always start with `x`. 
 
 To send a 10 grin transaction to the address `xd6p24toTTDj7sxCCM4WGpBVcegVjGi9q5jquq6VWZA1BJroX514`:
 ```
@@ -183,9 +183,20 @@ To import an existing grin wallet to use in wallet713 follow these steps:
 
 The following transaction addresses are currently supported.
 
-### 713.grinbox
-Assigned to you when you run the wallet for the first time.
+### Grinbox
+Assigned to you when you run the wallet for the first time. The address is derived from your seed.
 Typical address format: `grinbox://xd8q4wgBBwdg75vD2J1VswdT4x7bJE6P5o1hcoht99ebc6C1wxxq`
+
+####  Address derivation
+Addresses are derived from your wallet seed. A single seed can generate up to `2^32` different addresses. Each of your addresses is specified by an index, which defaults to 0.
+
+#### Switching address
+1. Stop the grinbox listener by using the `stop` command
+1. Run `config -g` to switch to the next address. This will display your new address.
+If instead you would like more control over which address to use, you can specify an index with the `-i` flag. For example, switching to the address with index `10` is done by running `config -g -i 10`.
+1. Start the grinbox listener again by running `listen`.
+
+The index will persist in between wallet713 sessions and is stored in your configuration file.
 
 ### Keybase
 Your username on [Keybase](https://keybase.io).

--- a/src/broker/grinbox.rs
+++ b/src/broker/grinbox.rs
@@ -6,7 +6,7 @@ use colored::*;
 use grin_core::libtx::slate::Slate;
 
 use common::{Error, Wallet713Error};
-use common::crypto::{SecretKey, PublicKey, Signature, verify_signature, sign_challenge, Hex, Base58};
+use common::crypto::{SecretKey, Signature, verify_signature, sign_challenge, Hex};
 use contacts::{Address, GrinboxAddress, DEFAULT_GRINBOX_PORT};
 
 use super::types::{Publisher, Subscriber, SubscriptionHandler, CloseReason};
@@ -188,7 +188,7 @@ impl GrinboxClient {
 
     fn verify_slate_signature(&self, from: &str, str: &str, challenge: &str, signature: &str) -> Result<(), Error> {
         let from = GrinboxAddress::from_str(from)?;
-        let public_key = PublicKey::from_base58_check(&from.public_key, 2)?;
+        let public_key = from.public_key()?;
         let signature = Signature::from_hex(signature)?;
         let mut challenge_builder = String::new();
         challenge_builder.push_str(str);

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -22,7 +22,10 @@ impl<'a, 'b> Parser {
                 SubCommand::with_name("config")
                     .about("configures wallet713")
                     .arg(
-                        Arg::from_usage("-g, --generate-keys 'generate new set of grinbox keys'")
+                        Arg::from_usage("[generate-address] -g, --generate-next-address 'generate new grinbox address, supports optional index `-i`'")
+                    )
+                    .arg(
+                        Arg::from_usage("[generate-address-index] -i, --index=<index> 'use this index for grinbox address generation'")
                     )
                     .arg(
                         Arg::from_usage("[data-path] -d, --data-path=<data path> 'the wallet data directory'")
@@ -32,9 +35,6 @@ impl<'a, 'b> Parser {
                     )
                     .arg(
                         Arg::from_usage("[port] -p, --port=<port> 'the grinbox port'")
-                    )
-                    .arg(
-                        Arg::from_usage("[private-key] --private-key=<private-key> 'the grinbox private key'")
                     )
                     .arg(
                         Arg::from_usage("[node-uri] -n, --node-uri=<uri> 'the grin node uri'")

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -11,7 +11,7 @@ use grin_core::global::ChainTypes;
 use super::Result;
 
 use contacts::{GrinboxAddress, DEFAULT_GRINBOX_PORT};
-use super::crypto::{SecretKey, PublicKey, public_key_from_secret_key, Hex, Base58, GRINBOX_ADDRESS_VERSION_TESTNET, GRINBOX_ADDRESS_VERSION_MAINNET};
+use super::crypto::{SecretKey, PublicKey, public_key_from_secret_key, Hex};
 
 const WALLET713_HOME: &str = ".wallet713";
 const WALLET713_DEFAULT_CONFIG_FILENAME: &str = "wallet713.toml";
@@ -130,15 +130,7 @@ impl Wallet713Config {
 
     pub fn get_grinbox_address(&self) -> Result<GrinboxAddress> {
         let public_key = self.get_grinbox_public_key()?;
-        let public_key = match self.chain {
-            None | Some(ChainTypes::Mainnet) => public_key.to_base58_check(GRINBOX_ADDRESS_VERSION_MAINNET.to_vec()),
-            Some(ChainTypes::AutomatedTesting) | Some(ChainTypes::UserTesting) | Some(ChainTypes::Floonet) => public_key.to_base58_check(GRINBOX_ADDRESS_VERSION_TESTNET.to_vec()),
-        };
-        let address = GrinboxAddress {
-            public_key,
-            domain: self.grinbox_domain.clone(),
-            port: self.grinbox_port,
-        };
+        let address = GrinboxAddress::new(public_key, self.grinbox_domain.clone(), self.grinbox_port);
         Ok(address)
     }
 

--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -1,4 +1,3 @@
-use rand::thread_rng;
 pub use grin_util::secp::{Message, Secp256k1, Signature};
 pub use grin_util::secp::key::{PublicKey ,SecretKey};
 
@@ -90,11 +89,6 @@ impl Hex<SecretKey> for SecretKey {
     fn to_hex(&self) -> String {
         to_hex(self.0.to_vec())
     }
-}
-
-pub fn generate_keypair() -> Result<(SecretKey, PublicKey)> {
-    let secp = Secp256k1::new();
-    secp.generate_keypair(&mut thread_rng()).map_err(|_| Wallet713Error::Secp.into())
 }
 
 pub fn public_key_from_secret_key(secret_key: &SecretKey) -> Result<PublicKey> {

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -63,8 +63,10 @@ pub enum Wallet713Error {
     DoesNotAcceptInvoices,
     #[fail(display = "rejecting invoice as amount '{}' is too big!", 0)]
     InvoiceAmountTooBig(u64),
-    #[fail(display = "please stop the Grinbox listener before doing this operation")]
-    GrinboxListening,
+    #[fail(display = "please stop the listeners before doing this operation")]
+    HasListener,
+    #[fail(display = "wallet already unlocked")]
+    WalletAlreadyUnlocked,
 }
 
 impl From<KeychainError> for Wallet713Error {

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -16,8 +16,6 @@ pub enum Wallet713Error {
     ClosedListener(String),
     #[fail(display = "listener for {} already started!", 0)]
     AlreadyListening(String),
-    #[fail(display = "`{}` is not a valid public key.", 0)]
-    InvalidContactPublicKey(String),
     #[fail(display = "contact named `{}` already exists!", 0)]
     ContactAlreadyExists(String),
     #[fail(display = "could not find contact named `{}`!", 0)]
@@ -28,6 +26,10 @@ pub enum Wallet713Error {
     InvalidBase58Length,
     #[fail(display = "invalid checksum!")]
     InvalidBase58Checksum,
+    #[fail(display = "invalid network!")]
+    InvalidBase58Version,
+    #[fail(display = "invalid key!")]
+    InvalidBase58Key,
     #[fail(display = "could not parse number from string!")]
     NumberParsingError,
     #[fail(display = "unknown address type `{}`!", 0)]
@@ -56,6 +58,4 @@ pub enum Wallet713Error {
     DoesNotAcceptInvoices,
     #[fail(display = "rejecting invoice as amount '{}' is too big!", 0)]
     InvoiceAmountTooBig(u64),
-    #[fail(display = "invalid version of grinbox address!")]
-    InvalidAddressVersion,
 }

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,7 +1,12 @@
 pub use failure::Error;
 
+use grin_keychain::Error as KeychainError;
+use grin_keychain::extkey_bip32::Error as ExtKeyError;
+
 #[derive(Debug, Fail)]
 pub enum Wallet713Error {
+    #[fail(display = "secp error")]
+    Secp,
     #[fail(display = "invalid transaction id given: `{}`", 0)]
     InvalidTxId(String),
     #[fail(display = "invalid amount given: `{}`", 0)]
@@ -58,4 +63,16 @@ pub enum Wallet713Error {
     DoesNotAcceptInvoices,
     #[fail(display = "rejecting invoice as amount '{}' is too big!", 0)]
     InvoiceAmountTooBig(u64),
+}
+
+impl From<KeychainError> for Wallet713Error {
+	fn from(_: KeychainError) -> Wallet713Error {
+		Wallet713Error::Secp
+	}
+}
+
+impl From<ExtKeyError> for Wallet713Error {
+	fn from(_: ExtKeyError) -> Wallet713Error {
+		Wallet713Error::Secp
+	}
 }

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -63,6 +63,8 @@ pub enum Wallet713Error {
     DoesNotAcceptInvoices,
     #[fail(display = "rejecting invoice as amount '{}' is too big!", 0)]
     InvoiceAmountTooBig(u64),
+    #[fail(display = "please stop the Grinbox listener before doing this operation")]
+    GrinboxListening,
 }
 
 impl From<KeychainError> for Wallet713Error {

--- a/src/common/hasher.rs
+++ b/src/common/hasher.rs
@@ -1,0 +1,80 @@
+use digest::generic_array::GenericArray;
+use hmac::{Hmac, Mac};
+use ripemd160::Ripemd160;
+use sha2::{Digest, Sha256, Sha512};
+
+use grin_core::global::is_floonet;
+use grin_keychain::Keychain;
+use grin_keychain::extkey_bip32::{BIP32Hasher, ChildNumber, ExtendedPrivKey};
+use grin_util::secp::key::SecretKey;
+
+use crate::common::Wallet713Error;
+
+type HmacSha512 = Hmac<Sha512>;
+
+#[derive(Clone, Debug)]
+pub struct BIP32GrinboxHasher {
+	is_floo: bool,
+	hmac_sha512: HmacSha512,
+}
+
+impl BIP32GrinboxHasher {
+	/// New empty hasher
+	pub fn new(is_floo: bool) -> Self {
+		Self {
+			is_floo,
+			hmac_sha512: HmacSha512::new(GenericArray::from_slice(&[0u8; 128])),
+		}
+	}
+}
+
+impl BIP32Hasher for BIP32GrinboxHasher {
+	fn network_priv(&self) -> [u8; 4] {
+		match self.is_floo {
+			true => [42, 0, 0, 42],
+			false => [42, 1, 0, 42],
+		}
+	}
+	fn network_pub(&self) -> [u8; 4] {
+		match self.is_floo {
+			true => [42, 0, 1, 42],
+			false => [42, 1, 1, 42],
+		}
+	}
+	fn master_seed() -> [u8; 12] {
+		b"Grinbox_seed".to_owned()
+	}
+	fn init_sha512(&mut self, seed: &[u8]) {
+		self.hmac_sha512 = HmacSha512::new_varkey(seed).expect("HMAC can take key of any size");;
+	}
+	fn append_sha512(&mut self, value: &[u8]) {
+		self.hmac_sha512.input(value);
+	}
+	fn result_sha512(&mut self) -> [u8; 64] {
+		let mut result = [0; 64];
+		result.copy_from_slice(self.hmac_sha512.result().code().as_slice());
+		result
+	}
+	fn sha_256(&self, input: &[u8]) -> [u8; 32] {
+		let mut sha2_res = [0; 32];
+		let mut sha2 = Sha256::new();
+		sha2.input(input);
+		sha2_res.copy_from_slice(sha2.result().as_slice());
+		sha2_res
+	}
+	fn ripemd_160(&self, input: &[u8]) -> [u8; 20] {
+		let mut ripemd_res = [0; 20];
+		let mut ripemd = Ripemd160::new();
+		ripemd.input(input);
+		ripemd_res.copy_from_slice(ripemd.result().as_slice());
+		ripemd_res
+	}
+}
+
+pub fn derive_address_key<K: Keychain>(keychain: &K, index: u32) -> Result<SecretKey, Wallet713Error> {
+	let root = keychain.derive_key(713, &K::root_key_id())?;
+	let mut hasher = BIP32GrinboxHasher::new(is_floonet());
+	let secp = keychain.secp();
+	let master = ExtendedPrivKey::new_master(secp, &mut hasher, &root.0)?;
+	Ok(master.ckd_priv(secp, &mut hasher, ChildNumber::from_normal_idx(index))?.secret_key)
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod config;
 pub mod base58;
 pub mod crypto;
+pub mod hasher;
 
 pub use self::error::Error;
 pub use self::error::Wallet713Error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,11 @@ extern crate colored;
 extern crate ws;
 extern crate futures;
 extern crate tokio;
-extern crate secp256k1;
 extern crate rand;
 extern crate sha2;
 extern crate digest;
+extern crate hmac;
+extern crate ripemd160;
 extern crate uuid;
 extern crate regex;
 extern crate rustyline;
@@ -58,7 +59,7 @@ fn do_config(args: &ArgMatches, chain: &Option<ChainTypes>, silent: bool) -> Res
 	} else {
 		config = Wallet713Config::default(&chain)?;
         if config.grin_node_secret.is_none() {
-            println!("{}: initilized new configuration with no api secret!", "WARNING".bright_yellow())
+            println!("{}: initialized new configuration with no api secret!", "WARNING".bright_yellow())
         }
 	}
 
@@ -96,8 +97,7 @@ fn do_config(args: &ArgMatches, chain: &Option<ChainTypes>, silent: bool) -> Res
     }
 
     if !exists || args.is_present("generate-keys") {
-        let (pr, _) = generate_keypair();
-        config.grinbox_private_key = pr.to_string();
+        let (pr, _) = generate_keypair()?;
         println!("{}: {}", "Your new 713.grinbox address".bright_yellow(), config.get_grinbox_address()?.stripped().bright_green());        any_matches = exists;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ extern crate grin_util;
 extern crate grin_core;
 extern crate grin_store;
 
+use failure::Error;
 use std::sync::{Arc, Mutex};
 use std::io::{Read, Write};
 use std::fs::File;
@@ -40,8 +41,7 @@ mod contacts;
 mod cli;
 
 use common::config::Wallet713Config;
-use common::{Wallet713Error, Result};
-use common::crypto::*;
+use common::{Wallet713Error};
 use wallet::Wallet;
 use cli::Parser;
 
@@ -49,7 +49,7 @@ use contacts::{Address, AddressType, GrinboxAddress, Contact, AddressBook, LMDBB
 
 const CLI_HISTORY_PATH: &str = ".history";
 
-fn do_config(args: &ArgMatches, chain: &Option<ChainTypes>, silent: bool) -> Result<Wallet713Config> {
+fn do_config(args: &ArgMatches, chain: &Option<ChainTypes>, silent: bool, new_address_index: Option<u32>) -> Result<Wallet713Config, Error> {
 	let mut config;
 	let mut any_matches = false;
     let config_path = args.value_of("config-path");
@@ -81,11 +81,6 @@ fn do_config(args: &ArgMatches, chain: &Option<ChainTypes>, silent: bool) -> Res
         any_matches = true;
     }
 
-    if let Some(account) = args.value_of("private-key") {
-        config.grinbox_private_key = Some(account.to_string()); // HERE
-        any_matches = true;
-    }
-
     if let Some(node_uri) = args.value_of("node-uri") {
         config.grin_node_uri = node_uri.to_string();
         any_matches = true;
@@ -96,11 +91,9 @@ fn do_config(args: &ArgMatches, chain: &Option<ChainTypes>, silent: bool) -> Res
         any_matches = true;
     }
 
-    if !exists || args.is_present("generate-keys") {
-        let (pr, _) = generate_keypair()?;
-        config.grinbox_private_key = Some(to_hex(pr.0.to_vec())); // HERE
-        println!("{}: {}", "Your new 713.grinbox address".bright_yellow(), config.get_grinbox_address()?.stripped().bright_green());
-        any_matches = exists;
+    if new_address_index.is_some() {
+        config.grinbox_address_index = new_address_index;
+        any_matches = true;
     }
 
     config.to_file(config_path)?;
@@ -112,7 +105,7 @@ fn do_config(args: &ArgMatches, chain: &Option<ChainTypes>, silent: bool) -> Res
     Ok(config)
 }
 
-fn do_contacts(args: &ArgMatches, address_book: Arc<Mutex<AddressBook>>) -> Result<()> {
+fn do_contacts(args: &ArgMatches, address_book: Arc<Mutex<AddressBook>>) -> Result<(), Error> {
     let mut address_book = address_book.lock().unwrap();
     if let Some(add_args) = args.subcommand_matches("add") {
         let name = add_args.value_of("name").expect("missing argument: name");
@@ -120,7 +113,7 @@ fn do_contacts(args: &ArgMatches, address_book: Arc<Mutex<AddressBook>>) -> Resu
 
         // try parse as a general address and fallback to grinbox address
         let contact_address = Address::parse(address);
-        let contact_address: Result<Box<Address>> = match contact_address {
+        let contact_address: Result<Box<Address>, Error> = match contact_address {
             Ok(address) => Ok(address),
             Err(e) => {
                 Ok(Box::new(GrinboxAddress::from_str(address).map_err(|_| e)?) as Box<Address>)
@@ -156,14 +149,14 @@ Welcome to wallet713
 const WELCOME_FOOTER: &str = r#"Use `listen` to connect to grinbox or `help` to see available commands
 "#;
 
-fn welcome(args: &ArgMatches) -> Result<Wallet713Config> {
+fn welcome(args: &ArgMatches) -> Result<Wallet713Config, Error> {
     let chain: Option<ChainTypes> = if args.is_present("floonet") {
         Some(ChainTypes::Floonet)
     } else {
         println!("Mainnet not ready yet! In the meantime run `wallet713 --floonet`");
         std::process::exit(1);
     };
-    let config = do_config(args, &chain, true)?;
+    let config = do_config(args, &chain, true, None)?;
     set_mining_mode(config.chain.clone().unwrap_or(ChainTypes::Mainnet));
 
     Ok(config)
@@ -181,7 +174,7 @@ struct Controller {
 }
 
 impl Controller {
-    pub fn new(name: &str, wallet: Arc<Mutex<Wallet>>, address_book: Arc<Mutex<AddressBook>>, publisher: Box<Publisher + Send>) -> Result<Self> {
+    pub fn new(name: &str, wallet: Arc<Mutex<Wallet>>, address_book: Arc<Mutex<AddressBook>>, publisher: Box<Publisher + Send>) -> Result<Self, Error> {
         Ok(Self {
             name: name.to_string(),
             wallet,
@@ -190,7 +183,7 @@ impl Controller {
         })
     }
 
-    fn process_incoming_slate(&self, slate: &mut Slate) -> Result<bool> {
+    fn process_incoming_slate(&self, slate: &mut Slate) -> Result<bool, Error> {
         if slate.num_participants > slate.participant_data.len() {
             //TODO: this needs to be changed to properly figure out if this slate is an invoice or a send
             if slate.tx.inputs().len() == 0 {
@@ -272,7 +265,7 @@ impl SubscriptionHandler for Controller {
     }
 }
 
-fn start_grinbox_listener(config: &Wallet713Config, wallet: Arc<Mutex<Wallet>>, address_book: Arc<Mutex<AddressBook>>) -> Result<(GrinboxPublisher, GrinboxSubscriber)> {
+fn start_grinbox_listener(config: &Wallet713Config, wallet: Arc<Mutex<Wallet>>, address_book: Arc<Mutex<AddressBook>>) -> Result<(GrinboxPublisher, GrinboxSubscriber), Error> {
     // make sure wallet is not locked, if it is try to unlock with no passphrase
     if let Ok(mut wallet) = wallet.lock() {
         if wallet.is_locked() {
@@ -299,7 +292,7 @@ fn start_grinbox_listener(config: &Wallet713Config, wallet: Arc<Mutex<Wallet>>, 
     Ok((grinbox_publisher, grinbox_subscriber))
 }
 
-fn start_keybase_listener(config: &Wallet713Config, wallet: Arc<Mutex<Wallet>>, address_book: Arc<Mutex<AddressBook>>) -> Result<(KeybasePublisher, KeybaseSubscriber)> {
+fn start_keybase_listener(config: &Wallet713Config, wallet: Arc<Mutex<Wallet>>, address_book: Arc<Mutex<AddressBook>>) -> Result<(KeybasePublisher, KeybaseSubscriber), Error> {
     // make sure wallet is not locked, if it is try to unlock with no passphrase
     if let Ok(mut wallet) = wallet.lock() {
         if wallet.is_locked() {
@@ -353,20 +346,25 @@ fn main() {
     let account = matches.value_of("account");
     let passphrase = matches.value_of("passphrase");
     let result = wallet.lock().unwrap().unlock(&config, account.unwrap_or("default"), passphrase.unwrap_or(""));
+    let has_wallet = result.is_ok();
+
+    print!("{}", WELCOME_HEADER.bright_yellow().bold());
     if account.is_some() || passphrase.is_some() {
         if let Err(err) = result {
-            cli_message!("{}: {}", "ERROR".bright_red(), err);
+            println!("{}: {}", "ERROR".bright_red(), err);
         }
     }
 
-    derive_address_key(&mut config, wallet.clone());
-
-    print!("{}", WELCOME_HEADER.bright_yellow().bold());
-    let x = config.get_grinbox_address();
-    println!("{:?}", x);
-//    println!("{:?}", x?);
-//    println!("{}: {}", "Your 713.grinbox address".bright_yellow(), config.get_grinbox_address()?.stripped().bright_green());
-    println!("{}", WELCOME_FOOTER.bright_blue().bold());
+    if has_wallet {
+        let der = derive_address_key(&mut config, wallet.clone(), &mut grinbox_broker);
+        if der.is_err() {
+            cli_message!("{}: {}", "ERROR".bright_red(), der.unwrap_err());
+        }
+    }
+    else {
+        println!("{}", "Unlock your existing wallet or type `init` to initiate a new one".bright_blue().bold());
+    }
+    println!("{}", WELCOME_FOOTER.bright_blue());
 
     if let Some(auto_start) = config.grinbox_listener_auto_start {
         if auto_start {
@@ -423,39 +421,75 @@ fn main() {
     }
 }
 
-fn derive_address_key(config: &mut Wallet713Config, wallet: Arc<Mutex<Wallet>>) {
-    let index = config.grinbox_address_index.unwrap_or(0);
-    println!("{:?}", index);
-    let x = wallet.lock().unwrap().derive_address_key(index);
-    println!("{:?}", x);
+fn derive_address_key(config: &mut Wallet713Config, wallet: Arc<Mutex<Wallet>>, grinbox_broker: &mut Option<(GrinboxPublisher, GrinboxSubscriber)>) -> Result<(), Error> {
+    if grinbox_broker.is_some() {
+        return Err(Wallet713Error::HasListener.into());
+    }
+    let index = config.grinbox_address_index();
+    let key = wallet.lock().unwrap().derive_address_key(index)?;
+    config.grinbox_address_key = Some(key);
+    println!("{}: {}", "Your grinbox address".bright_yellow(), config.get_grinbox_address()?.stripped().bright_green());
+    Ok(())
 }
 
-fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wallet>>, address_book: Arc<Mutex<AddressBook>>, keybase_broker: &mut Option<(KeybasePublisher, KeybaseSubscriber)>, grinbox_broker: &mut Option<(GrinboxPublisher, GrinboxSubscriber)>) -> Result<bool> {
+fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wallet>>, address_book: Arc<Mutex<AddressBook>>, keybase_broker: &mut Option<(KeybasePublisher, KeybaseSubscriber)>, grinbox_broker: &mut Option<(GrinboxPublisher, GrinboxSubscriber)>) -> Result<bool, Error> {
     let matches = Parser::parse(command)?;
     match matches.subcommand_name() {
         Some("config") => {
             let args = matches.subcommand_matches("config").unwrap();
-            *config = do_config(args, &config.chain, false)?;
+
+            let new_address_index = match args.is_present("generate-address") {
+                false => None,
+                true => Some({
+                        let index = match args.value_of("generate-address-index") {
+                            Some(index) => u32::from_str_radix(index, 10).map_err(|_| Wallet713Error::NumberParsingError)?,
+                            None => config.grinbox_address_index() + 1,
+                        };
+                        config.grinbox_address_index = Some(index);
+                        index
+                    }),
+            };
+
+            *config = do_config(args, &config.chain, false, new_address_index)?;
+
+            if new_address_index.is_some() {
+                println!("Derived new address with index {}", config.grinbox_address_index().to_string().yellow());
+                derive_address_key(config, wallet, grinbox_broker)?;
+            }
         },
         Some("init") => {
-            if grinbox_broker.is_some() {
-                return Err(Wallet713Error::GrinboxListening.into());
+            if keybase_broker.is_some() || grinbox_broker.is_some() {
+                return Err(Wallet713Error::HasListener.into());
             }
+
             let passphrase = matches.subcommand_matches("init").unwrap().value_of("passphrase").unwrap_or("");
-            wallet.lock().unwrap().init(config, "default", passphrase)?;
+            {
+                wallet.lock().unwrap().init(config, "default", passphrase)?;
+            }
+            derive_address_key(config, wallet, grinbox_broker)?;
             if passphrase.is_empty() {
                 cli_message!("{}: wallet with no passphrase.", "WARNING".bright_yellow());
             }
             return Ok(false);
         },
         Some("lock") => {
+            if keybase_broker.is_some() || grinbox_broker.is_some() {
+                return Err(Wallet713Error::HasListener.into());
+            }
             wallet.lock().unwrap().lock();
         },
         Some("unlock") => {
             let args = matches.subcommand_matches("unlock").unwrap();
             let account = args.value_of("account").unwrap_or("default");
             let passphrase = args.value_of("passphrase").unwrap_or("");
-            wallet.lock().unwrap().unlock(config, account, passphrase)?;
+            {
+                let mut w = wallet.lock().unwrap();
+                if !w.is_locked() {
+                    return Err(Wallet713Error::WalletAlreadyUnlocked.into());
+                }
+                w.unlock(config, account, passphrase)?;
+            }
+            derive_address_key(config, wallet, grinbox_broker)?;
             return Ok(false);
         },
         Some("accounts") => {
@@ -601,7 +635,7 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
 
             // try parse as a general address and fallback to grinbox address
             let address = Address::parse(&to);
-            let address: Result<Box<Address>> = match address {
+            let address: Result<Box<Address>, Error> = match address {
                 Ok(address) => Ok(address),
                 Err(e) => {
                     Ok(Box::new(GrinboxAddress::from_str(&to).map_err(|_| e)?) as Box<Address>)
@@ -609,7 +643,7 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
             };
 
             let to = address?;
-            let slate: Result<Slate> = match to.address_type() {
+            let slate: Result<Slate, Error> = match to.address_type() {
                 AddressType::Keybase => {
                     if let Some((publisher, _)) = keybase_broker {
                         let slate = wallet.lock().unwrap().initiate_send_tx(amount, 10, "smallest", change_outputs, 500, message)?;
@@ -661,7 +695,7 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
 
             // try parse as a general address
             let address = Address::parse(&to);
-            let address: Result<Box<Address>> = match address {
+            let address: Result<Box<Address>, Error> = match address {
                 Ok(address) => Ok(address),
                 Err(e) => {
                     Ok(Box::new(GrinboxAddress::from_str(&to).map_err(|_| e)?) as Box<Address>)
@@ -669,7 +703,7 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
             };
 
             let to = address?;
-            let slate: Result<Slate> = match to.address_type() {
+            let slate: Result<Slate, Error> = match to.address_type() {
                 AddressType::Keybase => {
                     if let Some((publisher, _)) = keybase_broker {
                         let slate = wallet.lock().unwrap().initiate_receive_tx(amount, outputs)?;

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use grin_util::Mutex;
+use grin_util::secp::key::SecretKey;
 use grin_wallet::{display, controller, WalletBackend, WalletInst, WalletConfig, WalletSeed, HTTPNodeClient, NodeClient};
 use grin_wallet::lmdb_wallet::LMDBBackend;
 use grin_core::libtx::slate::Slate;
@@ -8,6 +9,7 @@ use grin_keychain::keychain::ExtKeychain;
 
 use common::{Wallet713Error, Result};
 use common::config::Wallet713Config;
+use crate::common::hasher::derive_address_key;
 
 pub struct Wallet {
     active_account: String,
@@ -262,6 +264,13 @@ impl Wallet {
             Wallet713Error::GrinWalletPostError
         })?;
         Ok(())
+    }
+
+    pub fn derive_address_key(&self, index: u32) -> Result<SecretKey> {
+        let wallet = self.get_wallet_instance()?;
+        let mut w = wallet.lock();
+        w.open_with_credentials()?;
+        derive_address_key(w.keychain(), index).map_err(|e| e.into())
     }
 
     fn init_seed(&self, wallet_config: &WalletConfig, passphrase: &str) -> Result<WalletSeed> {


### PR DESCRIPTION
This PR removes the configuration option that stores the address secret key in the config. Instead it is now derived from the wallet seed.

It is possible to switch to a different derived address by calling `config -g`. This will increase the index by 1. If you want to use a custom index you can use `config -g -i <index>`.
Note that the Grinbox listener needs to be stopped before switching addresses.