### PR TITLE
Pay to HTTPS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,6 +2270,7 @@ dependencies = [
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grin_api 1.0.0 (git+https://github.com/mimblewimble/grin)",
  "grin_core 1.0.0 (git+https://github.com/mimblewimble/grin)",
  "grin_keychain 1.0.0 (git+https://github.com/mimblewimble/grin)",
  "grin_store 1.0.0 (git+https://github.com/mimblewimble/grin)",
@@ -2292,6 +2293,7 @@ dependencies = [
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,9 @@ term = "0.5"
 blake2-rfc = "0.2"
 log = "0.4"
 rpassword = "2.1.0"
+url = "1.7"
 
+grin_api = { git = "https://github.com/mimblewimble/grin" }
 grin_core = { git = "https://github.com/mimblewimble/grin" }
 grin_wallet = { git = "https://github.com/mimblewimble/grin" }
 grin_keychain = { git = "https://github.com/mimblewimble/grin" }

--- a/src/common/error_kind.rs
+++ b/src/common/error_kind.rs
@@ -63,6 +63,8 @@ pub enum ErrorKind {
     GrinboxAddressParsingError(String),
     #[fail(display = "could not parse `{}` to a keybase address!", 0)]
     KeybaseAddressParsingError(String),
+    #[fail(display = "could not parse `{}` to a https address!", 0)]
+    HttpsAddressParsingError(String),
     #[fail(display = "could not send keybase message!")]
     KeybaseMessageSendError,
     #[fail(display = "failed receiving slate!")]
@@ -93,4 +95,6 @@ pub enum ErrorKind {
     Restore,
     #[fail(display = "unknown account: {}", 0)]
     UnknownAccountLabel(String),
+    #[fail(display = "http request error")]
+    HttpRequest
 }


### PR DESCRIPTION
Resolves #77. Send to a listening wallet. For security reasons, only https is enabled. Example:
```
send 5 --to https://some.wallet.713.mw:13415
```