### PR TITLE
Add strategy and minimum confirmation options for send command

### DIFF
--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -172,6 +172,12 @@ impl<'a, 'b> Parser {
                         Arg::from_usage("<amount> 'the amount of grins to send'")
                     )
                     .arg(
+                        Arg::from_usage("[strategy] -s, --strategy=<strategy> 'the input selection strategy (all/smallest). Default: smallest'")
+                    )
+                    .arg(
+                        Arg::from_usage("[confirmations] -c, --confirmations=<confirmations> 'the number of confirmations required for inputs'")
+                    )
+                    .arg(
                         Arg::from_usage("[change-outputs] -o, --change-outputs=<change-outputs> 'the number of change outputs'")
                     )
                     .arg(

--- a/src/common/error_kind.rs
+++ b/src/common/error_kind.rs
@@ -31,6 +31,10 @@ pub enum ErrorKind {
     InvalidTxId(String),
     #[fail(display = "invalid amount given: `{}`", 0)]
     InvalidAmount(String),
+    #[fail(display = "invalid selection strategy, use either 'smallest' or 'all'")]
+    InvalidStrategy,
+    #[fail(display = "invalid number of minimum confirmations given: `{}`", 0)]
+    InvalidMinConfirmations(String),
     #[fail(display = "invalid number of outputs given: `{}`", 0)]
     InvalidNumOutputs(String),
     #[fail(display = "could not unlock wallet! are you using the correct passphrase?")]


### PR DESCRIPTION
When sending:
- set the input selection strategy (all/smallest) with the `-s` option
- set the minimum number of confirmation for inputs with the `-c` option