### PR TITLE
Store address in transaction log

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -192,13 +192,13 @@ impl Controller {
         })
     }
 
-    fn process_incoming_slate(&self, slate: &mut Slate) -> Result<bool> {
+    fn process_incoming_slate(&self, address: Option<String>, slate: &mut Slate) -> Result<bool> {
         if slate.num_participants > slate.participant_data.len() {
             //TODO: this needs to be changed to properly figure out if this slate is an invoice or a send
             if slate.tx.inputs().len() == 0 {
                 self.wallet.lock().unwrap().process_receiver_initiated_slate(slate)?;
             } else {
-                self.wallet.lock().unwrap().process_sender_initiated_slate(slate)?;
+                self.wallet.lock().unwrap().process_sender_initiated_slate(address, slate)?;
             }
             Ok(false)
         } else {
@@ -237,7 +237,7 @@ impl SubscriptionHandler for Controller {
             GrinboxAddress::from_str(&from.to_string()).expect("invalid grinbox address");
         }
 
-        let result = self.process_incoming_slate(slate).and_then(|is_finalized| {
+        let result = self.process_incoming_slate(Some(from.to_string()), slate).and_then(|is_finalized| {
             if !is_finalized {
                 self.publisher.post_slate(slate, from).map_err(|e| {
                     cli_message!("{}: {}", "ERROR".bright_red(), e);
@@ -659,7 +659,7 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
             file.read_to_string(&mut slate)?;
             let mut slate: Slate = serde_json::from_str(&slate)?;
             let mut file = File::create(&format!("{}.response", input))?;
-            wallet.lock().unwrap().process_sender_initiated_slate(&mut slate)?;
+            wallet.lock().unwrap().process_sender_initiated_slate(Some(String::from("file")), &mut slate)?;
             cli_message!("{} received.", input);
             file.write_all(serde_json::to_string(&slate).unwrap().as_bytes())?;
             cli_message!("{}.response created successfully.", input);
@@ -700,9 +700,10 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
                 ErrorKind::InvalidAmount(amount.to_string())
             })?;
 
+            // Store slate in a file
             if let Some(input) = input {
                 let mut file = File::create(input)?;
-                let slate = wallet.lock().unwrap().initiate_send_tx(amount, confirmations, strategy, change_outputs, 500, message)?;
+                let slate = wallet.lock().unwrap().initiate_send_tx(Some(String::from("file")), amount, confirmations, strategy, change_outputs, 500, message)?;
                 file.write_all(serde_json::to_string(&slate).unwrap().as_bytes())?;
                 cli_message!("{} created successfully.", input);
                 return Ok(true);
@@ -722,12 +723,11 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
                     Ok(Box::new(GrinboxAddress::from_str(&to).map_err(|_| e)?) as Box<Address>)
                 }
             };
-
             let to = address?;
             let slate: Result<Slate> = match to.address_type() {
                 AddressType::Keybase => {
                     if let Some((publisher, _)) = keybase_broker {
-                        let slate = wallet.lock().unwrap().initiate_send_tx(amount, confirmations, strategy, change_outputs, 500, message)?;
+                        let slate = wallet.lock().unwrap().initiate_send_tx(Some(to.to_string()), amount, confirmations, strategy, change_outputs, 500, message)?;
                         let mut keybase_address = contacts::KeybaseAddress::from_str(&to.to_string())?;
                         keybase_address.topic = Some(broker::TOPIC_SLATE_NEW.to_string());
                         publisher.post_slate(&slate, keybase_address.borrow())?;
@@ -738,7 +738,7 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
                 }
                 AddressType::Grinbox => {
                     if let Some((publisher, _)) = grinbox_broker {
-                        let slate = wallet.lock().unwrap().initiate_send_tx(amount, confirmations, strategy, change_outputs, 500, message)?;
+                        let slate = wallet.lock().unwrap().initiate_send_tx(Some(to.to_string()), amount, confirmations, strategy, change_outputs, 500, message)?;
                         publisher.post_slate(&slate, to.borrow())?;
                         Ok(slate)
                     } else {
@@ -747,7 +747,7 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
                 },
                 AddressType::Https => {
                     let url = Url::parse(&format!("{}/v1/wallet/foreign/receive_tx", to.to_string()))?;
-                    let slate = wallet.lock().unwrap().initiate_send_tx(amount, confirmations, strategy, change_outputs, 500, message)?;
+                    let slate = wallet.lock().unwrap().initiate_send_tx(Some(to.to_string()), amount, confirmations, strategy, change_outputs, 500, message)?;
                     client::post(url.as_str(), None, &slate)
                         .map_err(|_| ErrorKind::HttpRequest.into())
                 }

--- a/src/wallet/api/api.rs
+++ b/src/wallet/api/api.rs
@@ -154,6 +154,7 @@ impl<W: ?Sized, C, K> Wallet713OwnerAPI<W, C, K>
 
     pub fn initiate_tx(
         &mut self,
+        address: Option<String>,
         amount: u64,
         minimum_confirmations: u64,
         max_outputs: usize,
@@ -172,6 +173,7 @@ impl<W: ?Sized, C, K> Wallet713OwnerAPI<W, C, K>
         let parent_key_id = w.get_parent_key_id();
         let (slate, context, lock_fn) = tx::create_send_tx(
             &mut *w,
+            address,
             amount,
             minimum_confirmations,
             max_outputs,
@@ -374,6 +376,7 @@ impl<W: ?Sized, C, K> Wallet713ForeignAPI<W, C, K>
 
     pub fn receive_tx(
         &mut self,
+        address: Option<String>,
         slate: &mut Slate,
         message: Option<String>,
     ) -> Result<(), Error> {
@@ -387,7 +390,7 @@ impl<W: ?Sized, C, K> Wallet713ForeignAPI<W, C, K>
                 return Err(ErrorKind::TransactionAlreadyReceived(slate.id.to_string()).into());
             }
         }
-        let res = tx::receive_tx(&mut *w, slate, &parent_key_id, message);
+        let res = tx::receive_tx(&mut *w, address, slate, &parent_key_id, message);
         w.close()?;
 
         if let Err(e) = res {

--- a/src/wallet/api/display.rs
+++ b/src/wallet/api/display.rs
@@ -128,38 +128,33 @@ pub fn txs(
     table.set_titles(row![
 		bMG->"Id",
 		bMG->"Type",
-		bMG->"Shared Transaction Id",
+		bMG->"TXID",
+		bMG->"Address",
 		bMG->"Creation Time",
 		bMG->"Confirmed?",
 		bMG->"Confirmation Time",
-		bMG->"Num. \nInputs",
-		bMG->"Num. \nOutputs",
-		bMG->"Amount \nCredited",
-		bMG->"Amount \nDebited",
-		bMG->"Fee",
 		bMG->"Net \nDifference",
 	]);
 
     for t in txs {
         let id = format!("{}", t.id);
         let slate_id = match t.tx_slate_id {
-            Some(m) => format!("{}", m),
-            None => "None".to_owned(),
+            Some(m) => grin_util::to_hex(m.as_bytes()[..4].to_vec()),
+            None => String::from(""),
+        };
+        let address = match t.address {
+            Some(a) => a.clone(),
+            None => String::from(""),
         };
         let entry_type = format!("{}", t.tx_type);
         let creation_ts = format!("{}", t.creation_ts.format("%Y-%m-%d %H:%M:%S"));
         let confirmation_ts = match t.confirmation_ts {
             Some(m) => format!("{}", m.format("%Y-%m-%d %H:%M:%S")),
-            None => "None".to_owned(),
+            None => String::from(""),
         };
-        let confirmed = format!("{}", t.confirmed);
-        let num_inputs = format!("{}", t.num_inputs);
-        let num_outputs = format!("{}", t.num_outputs);
-        let amount_debited_str = core::amount_to_hr_string(t.amount_debited, true);
-        let amount_credited_str = core::amount_to_hr_string(t.amount_credited, true);
-        let fee = match t.fee {
-            Some(f) => format!("{}", core::amount_to_hr_string(f, true)),
-            None => "None".to_owned(),
+        let confirmed = match t.confirmed {
+            true => "yes",
+            false => "no",
         };
         let net_diff = if t.amount_credited >= t.amount_debited {
             core::amount_to_hr_string(t.amount_credited - t.amount_debited, true)
@@ -173,15 +168,11 @@ pub fn txs(
             table.add_row(row![
 				bFC->id,
 				bFC->entry_type,
-				bFC->slate_id,
+				bFB->slate_id,
+				bFC->address,
 				bFB->creation_ts,
 				bFC->confirmed,
 				bFB->confirmation_ts,
-				bFC->num_inputs,
-				bFC->num_outputs,
-				bFG->amount_credited_str,
-				bFR->amount_debited_str,
-				bFR->fee,
 				bFY->net_diff,
 			]);
         } else {
@@ -190,14 +181,10 @@ pub fn txs(
 					bFD->id,
 					bFb->entry_type,
 					bFD->slate_id,
+					bFD->address,
 					bFB->creation_ts,
 					bFg->confirmed,
 					bFB->confirmation_ts,
-					bFD->num_inputs,
-					bFD->num_outputs,
-					bFG->amount_credited_str,
-					bFD->amount_debited_str,
-					bFD->fee,
 					bFG->net_diff,
 				]);
             } else {
@@ -205,14 +192,10 @@ pub fn txs(
 					bFD->id,
 					bFb->entry_type,
 					bFD->slate_id,
+					bFD->address,
 					bFB->creation_ts,
 					bFR->confirmed,
 					bFB->confirmation_ts,
-					bFD->num_inputs,
-					bFD->num_outputs,
-					bFG->amount_credited_str,
-					bFD->amount_debited_str,
-					bFD->fee,
 					bFG->net_diff,
 				]);
             }

--- a/src/wallet/api/selection.rs
+++ b/src/wallet/api/selection.rs
@@ -7,6 +7,7 @@ use super::keys;
 
 pub fn build_send_tx_slate<T: ?Sized, C, K>(
     wallet: &mut T,
+    address: Option<String>,
     num_participants: usize,
     amount: u64,
     current_height: u64,
@@ -84,6 +85,7 @@ pub fn build_send_tx_slate<T: ?Sized, C, K>(
         let log_id = batch.next_tx_log_id(&parent_key_id)?;
         let mut t = TxLogEntry::new(parent_key_id.clone(), TxLogEntryType::TxSent, log_id);
         t.tx_slate_id = Some(slate_id);
+        t.address = address;
         t.fee = Some(fee);
         let mut amount_debited = 0;
         t.num_inputs = lock_inputs.len();
@@ -126,6 +128,7 @@ pub fn build_send_tx_slate<T: ?Sized, C, K>(
 
 pub fn build_recipient_output_with_slate<T: ?Sized, C, K>(
     wallet: &mut T,
+    address: Option<String>,
     slate: &mut Slate,
     parent_key_id: Identifier,
 ) -> Result<
@@ -172,6 +175,7 @@ pub fn build_recipient_output_with_slate<T: ?Sized, C, K>(
         let log_id = batch.next_tx_log_id(&parent_key_id)?;
         let mut t = TxLogEntry::new(parent_key_id.clone(), TxLogEntryType::TxReceived, log_id);
         t.tx_slate_id = Some(slate_id);
+        t.address = address;
         t.amount_credited = amount;
         t.num_outputs = 1;
         batch.save_output(&OutputData {

--- a/src/wallet/api/tx.rs
+++ b/src/wallet/api/tx.rs
@@ -6,6 +6,7 @@ use super::updater;
 
 pub fn receive_tx<T: ?Sized, C, K>(
     wallet: &mut T,
+    address: Option<String>,
     slate: &mut Slate,
     parent_key_id: &Identifier,
     message: Option<String>,
@@ -17,7 +18,7 @@ pub fn receive_tx<T: ?Sized, C, K>(
 {
     // create an output using the amount in the slate
     let (_, mut context, receiver_create_fn) =
-        selection::build_recipient_output_with_slate(wallet, slate, parent_key_id.clone())?;
+        selection::build_recipient_output_with_slate(wallet, address, slate, parent_key_id.clone())?;
 
     // fill public keys
     let _ = slate.fill_round_1(
@@ -39,6 +40,7 @@ pub fn receive_tx<T: ?Sized, C, K>(
 
 pub fn create_send_tx<T: ?Sized, C, K>(
     wallet: &mut T,
+    address: Option<String>,
     amount: u64,
     minimum_confirmations: u64,
     max_outputs: usize,
@@ -75,6 +77,7 @@ pub fn create_send_tx<T: ?Sized, C, K>(
     // this process can be split up in any way
     let (mut slate, mut context, sender_lock_fn) = selection::build_send_tx_slate(
         wallet,
+        address,
         2,
         amount,
         current_height,

--- a/src/wallet/types/tx_log_entry.rs
+++ b/src/wallet/types/tx_log_entry.rs
@@ -17,6 +17,9 @@ pub struct TxLogEntry {
     pub tx_slate_id: Option<Uuid>,
     /// Transaction type (as above)
     pub tx_type: TxLogEntryType,
+    /// Address of the other party
+    #[serde(default)]
+    pub address: Option<String>,
     /// Time this tx entry was created
     /// #[serde(with = "tx_date_format")]
     pub creation_ts: DateTime<Utc>,
@@ -46,6 +49,7 @@ impl TxLogEntry {
             parent_key_id: parent_key_id,
             tx_type: t,
             id: id,
+            address: None,
             tx_slate_id: None,
             creation_ts: Utc::now(),
             confirmation_ts: None,

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -126,11 +126,12 @@ impl Wallet {
         Ok(result)
     }
 
-    pub fn initiate_send_tx(&self, amount: u64, minimum_confirmations: u64, selection_strategy: &str, change_outputs: usize, max_outputs: usize, message: Option<String>) -> Result<Slate> {
+    pub fn initiate_send_tx(&self, address: Option<String>, amount: u64, minimum_confirmations: u64, selection_strategy: &str, change_outputs: usize, max_outputs: usize, message: Option<String>) -> Result<Slate> {
         let wallet = self.get_wallet_instance()?;
         let mut s: Slate = Slate::blank(0);
         controller::owner_single_use(wallet.clone(), |api| {
             let (slate, lock_fn) = api.initiate_tx(
+                address,
                 amount,
                 minimum_confirmations,
                 max_outputs,
@@ -208,10 +209,10 @@ impl Wallet {
         Ok(())
     }
 
-    pub fn process_sender_initiated_slate(&self, slate: &mut Slate) -> Result<()> {
+    pub fn process_sender_initiated_slate(&self, address: Option<String>, slate: &mut Slate) -> Result<()> {
         let wallet = self.get_wallet_instance()?;
         controller::foreign_single_use(wallet.clone(), |api| {
-            api.receive_tx(slate, None)?;
+            api.receive_tx(address, slate, None)?;
             Ok(())
         }).map_err(|_| {
             ErrorKind::GrinWalletReceiveError


### PR DESCRIPTION
With this PR, the address of the sender/receiver is stored in the transaction log. Using the `txs` command will show the address in the table.