### PR TITLE
Add destination field to encrypted message

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -173,13 +173,13 @@ Thanks to the use of grinbox, wallet713 supports proving that a particular amoun
 
 In the below example,
 1. Alice wants to send Bob 1.337 grins and prove to Carol that this transaction has occurred.
-1. Bob has grinbox address: `xd7auPddUmmEzSte48a2aZ9tWkjjCppgn41pemUfcVSqjxHHZ6cT`;
+1. Bob has grinbox address: `xd7sCQ9bQuQXp4yCn8GSELcuSxnpcPrPoEWJzvPBc5vxyXPQz6PJ`;
 
 #### Creating a transaction proof
 
 1. Alice uses grinbox to send Bob grins using grinbox and broadcasts the transaction to the blockchain:
    ```
-   wallet713> $ send 1.337 --to xd7auPddUmmEzSte48a2aZ9tWkjjCppgn41pemUfcVSqjxHHZ6cT
+   wallet713> $ send 0.233232 --to xd7sCQ9bQuQXp4yCn8GSELcuSxnpcPrPoEWJzvPBc5vxyXPQz6PJ
    ```
 1. Alice runs `txs` command to display the transaction log and to identify which ID her transaction has:
    ```
@@ -187,7 +187,7 @@ In the below example,
    ```
    The transaction in question should show a `yes` in the `proof` column. Example output:
    ```
-    23  Sent Tx      4b6ede9f  grinbox://xd7auPddUmmEzSte48a2aZ9tWkjjCppgn41pemUfcVSqjxHHZ6cT                 2019-01-27 20:45:01  yes         2019-01-31 01:02:18  -1.338      yes 
+    23  Sent Tx      4b6ede9f  grinbox://xd7sCQ9bQuQXp4yCn8GSELcuSxnpcPrPoEWJzvPBc5vxyXPQz6PJ                 2019-01-27 20:45:01  yes         2019-01-31 01:02:18  -0.234232      yes 
    ```
 
 1. Alice now generates a proof for this transaction:
@@ -213,7 +213,7 @@ In the below example,
    ```
 1. Alice can now send `proof.txt` to Carol, who then can use it to verify the proof. As per the output note above, the proof **is only valid if the kernel in question is found on-chain**. One way to verify this is to locate the specific kernel in a block using a blockchain explorer.
 
-**IMPORTANT NOTE:** When sending to older versions of the wallet, the address of the sender might be missing. In this case the proof only proves that the address of the receiving party. In this case, anyone in posession of this proof can claim they were the sender. If the sender field is missing, a warning will be displayed.
+**IMPORTANT NOTE:** When sending to older versions of the wallet, the address of the sender might be missing. In this case the proof only proves that the address of the receiving party. Anyone in posession of this proof can claim they were the sender. If the sender field is missing, a warning will be displayed.
 
 #### Verifying a transaction proof
 
@@ -237,7 +237,7 @@ please use a grin block explorer to verify this is the case. for example:
 ```
 Once again, as per the output note above, the proof **is only valid if the kernel in question is found on-chain**. One way to verify this is to locat the specific kernel in a block using a blockchain explorer.
 
-**IMPORTANT NOTE:** When sending to older versions of the wallet, the address of the sender might be missing. In this case the proof only proves that the address of the receiving party. In this case, anyone in posession of this proof can claim they were the sender. If the sender field is missing, a warning will be displayed.
+**IMPORTANT NOTE:** When sending to older versions of the wallet, the address of the sender might be missing. In this case the proof only proves that the address of the receiving party. Anyone in posession of this proof can claim they were the sender. If the sender field is missing, a warning will be displayed.
 
 ### Using Contacts
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,7 +19,7 @@ While running, wallet713 works with an internal command prompt. You type command
     + [Send configurations](#send-configurations)
       - [Input selection strategy](#input-selection-strategy)
       - [Minimum number of confirmations](#minimum-number-of-confirmations)
-    + [Transaction proofs (grinbox only)](#transaction-proofs--grinbox-only-)
+    + [Transaction proofs (grinbox only)](#transaction-proofs-grinbox-only)
       - [Creating a transaction proof](#creating-a-transaction-proof)
       - [Verifying a transaction proof](#verifying-a-transaction-proof)
     + [Using Contacts](#using-contacts)
@@ -200,19 +200,20 @@ In the below example,
    ```
    wallet713> $ export-proof -i 23 -f proof.txt
    proof written to proof.txt
-   this file proves that [xd7auPddUmmEzSte48a2aZ9tWkjjCppgn41pemUfcVSqjxHHZ6cT] received [1.337000000] grins
+   this file proves that [0.233232000] grins was sent to [xd7sCQ9bQuQXp4yCn8GSELcuSxnpcPrPoEWJzvPBc5vxyXPQz6PJ] from [xd7auPddUmmEzSte48a2aZ9tWkjjCppgn41pemUfcVSqjxHHZ6cT]
+
    outputs:
-   0954b3ba69ad08e4e3e413d856997e2af1d986403d302efd4bc934959249ba4d64
+      08710be0b3fffa79b9423f8e007709a815f237dcfd31340cfa1fdfefd823dca30e
    kernel:
-   02bbbd9f7b70ad4782e301fdb5a6ecce511015d77f7f7d06c2323c001214dc2c41
-   
+      099c8a166acd426481c1b09707b9e6cdabb69718ee3ca86694579bf98a42c0c80d
+
    WARNING: this proof should only be considered valid if the kernel is actually on-chain with sufficient confirmations
    please use a grin block explorer to verify this is the case. for example:
-   https://floonet.grinscan.net/kernel/02bbbd9f7b70ad4782e301fdb5a6ecce511015d77f7f7d06c2323c001214dc2c41
+      https://floonet.grinscan.net/kernel/099c8a166acd426481c1b09707b9e6cdabb69718ee3ca86694579bf98a42c0c80d
    ```
 1. Alice can now send `proof.txt` to Carol, who then can use it to verify the proof. As per the output note above, the proof **is only valid if the kernel in question is found on-chain**. One way to verify this is to locate the specific kernel in a block using a blockchain explorer.
 
-**IMPORTANT NOTE:** This proof only proves that Bob's grinbox address received the corresponding amount of grins,but not that it was _Alice_ who sent the funds. Anyone in posession of this proof can claim they were the sender.
+**IMPORTANT NOTE:** When sending to older versions of the wallet, the address of the sender might be missing. In this case the proof only proves that the address of the receiving party. In this case, anyone in posession of this proof can claim they were the sender. If the sender field is missing, a warning will be displayed.
 
 #### Verifying a transaction proof
 
@@ -223,20 +224,20 @@ wallet713> $ verify-proof -f <filename>
 ...where `<filename>` is the file path to the proof that should be verified (such as `proof.txt`). Example output:
 ```
 wallet713> $ verify-proof -f proof.txt
-proof verification succesful!
-this file proves that [xd7auPddUmmEzSte48a2aZ9tWkjjCppgn41pemUfcVSqjxHHZ6cT] received [1.337000000] grins
+this file proves that [0.233232000] grins was sent to [xd7sCQ9bQuQXp4yCn8GSELcuSxnpcPrPoEWJzvPBc5vxyXPQz6PJ] from [xd7auPddUmmEzSte48a2aZ9tWkjjCppgn41pemUfcVSqjxHHZ6cT]
+
 outputs:
-   0954b3ba69ad08e4e3e413d856997e2af1d986403d302efd4bc934959249ba4d64
+  08710be0b3fffa79b9423f8e007709a815f237dcfd31340cfa1fdfefd823dca30e
 kernel:
-   02bbbd9f7b70ad4782e301fdb5a6ecce511015d77f7f7d06c2323c001214dc2c41
+  099c8a166acd426481c1b09707b9e6cdabb69718ee3ca86694579bf98a42c0c80d
 
 WARNING: this proof should only be considered valid if the kernel is actually on-chain with sufficient confirmations
 please use a grin block explorer to verify this is the case. for example:
-   https://floonet.grinscan.net/kernel/02bbbd9f7b70ad4782e301fdb5a6ecce511015d77f7f7d06c2323c001214dc2c41
+  https://floonet.grinscan.net/kernel/099c8a166acd426481c1b09707b9e6cdabb69718ee3ca86694579bf98a42c0c80d
 ```
 Once again, as per the output note above, the proof **is only valid if the kernel in question is found on-chain**. One way to verify this is to locat the specific kernel in a block using a blockchain explorer.
 
-**IMPORTANT NOTE:** This proof only proves that Bob's grinbox address received the corresponding amount of grins,but not that it was _Alice_ who sent the funds. Anyone in posession of this proof can claim they were the sender.
+**IMPORTANT NOTE:** When sending to older versions of the wallet, the address of the sender might be missing. In this case the proof only proves that the address of the receiving party. In this case, anyone in posession of this proof can claim they were the sender. If the sender field is missing, a warning will be displayed.
 
 ### Using Contacts
 

--- a/src/broker/grinbox.rs
+++ b/src/broker/grinbox.rs
@@ -6,7 +6,8 @@ use grin_core::libtx::slate::Slate;
 
 use crate::wallet::types::{TxProofErrorKind, TxProof};
 use common::{ErrorKind, Result, Arc, Mutex};
-use common::crypto::{SecretKey, sign_challenge, Hex, EncryptedMessage};
+use common::crypto::{SecretKey, sign_challenge, Hex};
+use common::message::EncryptedMessage;
 use contacts::{Address, GrinboxAddress, DEFAULT_GRINBOX_PORT};
 
 use super::types::{Publisher, Subscriber, SubscriptionHandler, CloseReason};
@@ -116,7 +117,7 @@ impl GrinboxBroker {
                 let response = serde_json::from_str::<ProtocolResponse>(&msg.to_string()).expect("could not parse response!");
                 match response {
                     ProtocolResponse::Challenge { str } => {
-                        let message = EncryptedMessage::new(serde_json::to_string(&slate).unwrap(), to.to_string(), &pkey, &skey).map_err(|_|
+                        let message = EncryptedMessage::new(serde_json::to_string(&slate).unwrap(), &to, &pkey, &skey).map_err(|_|
                             WsError::new(WsErrorKind::Protocol, "could not encrypt slate!")
                         )?;
                         let slate_str = serde_json::to_string(&message).unwrap();

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -117,7 +117,7 @@ impl Wallet713Config {
 
     pub fn get_grinbox_address(&self) -> Result<GrinboxAddress> {
         let public_key = self.get_grinbox_public_key()?;
-        Ok(GrinboxAddress::new(public_key, self.grinbox_domain.clone(), self.grinbox_port))
+        Ok(GrinboxAddress::new(public_key, Some(self.grinbox_domain.clone()), self.grinbox_port))
     }
 
     pub fn get_grinbox_public_key(&self) -> Result<PublicKey> {

--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -119,13 +119,15 @@ pub fn verify_signature(challenge: &str, signature: &Signature, public_key: &Pub
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EncryptedMessage {
+    #[serde(default)]
+    pub destination: Option<String>,
     encrypted_message: String,
     salt: String,
     nonce: String,
 }
 
 impl EncryptedMessage {
-    pub fn new(message: String, receiver_public_key: &PublicKey, secret_key: &SecretKey) -> Result<EncryptedMessage> {
+    pub fn new(message: String, destination: String, receiver_public_key: &PublicKey, secret_key: &SecretKey) -> Result<EncryptedMessage> {
         let secp = Secp256k1::new();
         let mut common_secret = receiver_public_key.clone();
         common_secret.mul_assign(&secp, secret_key).map_err(|_| ErrorKind::Encryption)?;
@@ -147,6 +149,7 @@ impl EncryptedMessage {
             .map_err(|_| ErrorKind::Encryption)?;
 
         Ok(EncryptedMessage {
+            destination: Some(destination),
             encrypted_message: to_hex(enc_bytes),
             salt: to_hex(salt.to_vec()),
             nonce: to_hex(nonce.to_vec()),

--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -1,5 +1,6 @@
 pub use grin_util::secp::{Message, Secp256k1, Signature};
 pub use grin_util::secp::key::{PublicKey ,SecretKey};
+use grin_util::secp::pedersen::Commitment;
 
 use std::fmt::Write;
 use super::base58::{ToBase58, FromBase58};
@@ -85,6 +86,17 @@ impl Hex<SecretKey> for SecretKey {
         let secp = Secp256k1::new();
         let data = from_hex(str.to_string())?;
         SecretKey::from_slice(&secp, &data).map_err(|_| ErrorKind::Secp.into())
+    }
+
+    fn to_hex(&self) -> String {
+        to_hex(self.0.to_vec())
+    }
+}
+
+impl Hex<Commitment> for Commitment {
+    fn from_hex(str: &str) -> Result<Commitment> {
+        let data = from_hex(str.to_string())?;
+        Ok(Commitment::from_vec(data))
     }
 
     fn to_hex(&self) -> String {

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -1,0 +1,77 @@
+use grin_util::secp::Secp256k1;
+use grin_util::secp::key::{PublicKey, SecretKey};
+use rand::Rng;
+use rand::thread_rng;
+use ring::aead;
+use ring::{digest, pbkdf2};
+
+use crate::common::{ErrorKind, Result};
+use crate::common::crypto::{from_hex, to_hex};
+use crate::contacts::GrinboxAddress;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EncryptedMessage {
+    #[serde(default)]
+    pub destination: Option<GrinboxAddress>,
+    encrypted_message: String,
+    salt: String,
+    nonce: String,
+}
+
+impl EncryptedMessage {
+    pub fn new(message: String, destination: &GrinboxAddress, receiver_public_key: &PublicKey, secret_key: &SecretKey) -> Result<EncryptedMessage> {
+        let secp = Secp256k1::new();
+        let mut common_secret = receiver_public_key.clone();
+        common_secret.mul_assign(&secp, secret_key).map_err(|_| ErrorKind::Encryption)?;
+        let common_secret_ser = common_secret.serialize_vec(&secp, true);
+        let common_secret_slice = &common_secret_ser[1..33];
+
+        let salt: [u8; 8] = thread_rng().gen();
+        let nonce: [u8; 12] = thread_rng().gen();
+        let mut key = [0; 32];
+        pbkdf2::derive(&digest::SHA512, 100, &salt, common_secret_slice, &mut key);
+        let mut enc_bytes = message.as_bytes().to_vec();
+        let suffix_len = aead::CHACHA20_POLY1305.tag_len();
+        for _ in 0..suffix_len {
+            enc_bytes.push(0);
+        }
+        let sealing_key = aead::SealingKey::new(&aead::CHACHA20_POLY1305, &key)
+            .map_err(|_| ErrorKind::Encryption)?;
+        aead::seal_in_place(&sealing_key, &nonce, &[], &mut enc_bytes, suffix_len)
+            .map_err(|_| ErrorKind::Encryption)?;
+
+        Ok(EncryptedMessage {
+            destination: Some(destination.clone()),
+            encrypted_message: to_hex(enc_bytes),
+            salt: to_hex(salt.to_vec()),
+            nonce: to_hex(nonce.to_vec()),
+        })
+    }
+
+    pub fn key(&self, sender_public_key: &PublicKey, secret_key: &SecretKey) -> Result<[u8; 32]> {
+        let salt = from_hex(self.salt.clone()).map_err(|_| ErrorKind::Decryption)?;
+
+        let secp = Secp256k1::new();
+        let mut common_secret = sender_public_key.clone();
+        common_secret.mul_assign(&secp, secret_key).map_err(|_| ErrorKind::Decryption)?;
+        let common_secret_ser = common_secret.serialize_vec(&secp, true);
+        let common_secret_slice = &common_secret_ser[1..33];
+
+        let mut key = [0; 32];
+        pbkdf2::derive(&digest::SHA512, 100, &salt, common_secret_slice, &mut key);
+
+        Ok(key)
+    }
+
+    pub fn decrypt_with_key(&self, key: &[u8; 32]) -> Result<String> {
+        let mut encrypted_message = from_hex(self.encrypted_message.clone()).map_err(|_| ErrorKind::Decryption)?;
+        let nonce = from_hex(self.nonce.clone()).map_err(|_| ErrorKind::Decryption)?;
+
+        let opening_key = aead::OpeningKey::new(&aead::CHACHA20_POLY1305, key)
+            .map_err(|_| ErrorKind::Decryption)?;
+        let decrypted_data = aead::open_in_place(&opening_key, &nonce, &[], 0, &mut encrypted_message)
+            .map_err(|_| ErrorKind::Decryption)?;
+
+        String::from_utf8(decrypted_data.to_vec()).map_err(|_| ErrorKind::Decryption.into())
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,6 +4,7 @@ pub mod base58;
 pub mod crypto;
 pub mod hasher;
 mod error_kind;
+pub mod message;
 
 pub use self::error_kind::ErrorKind;
 pub use self::macros::*;

--- a/src/contacts/types.rs
+++ b/src/contacts/types.rs
@@ -195,10 +195,10 @@ pub struct GrinboxAddress {
 }
 
 impl GrinboxAddress {
-    pub fn new(public_key: PublicKey, domain: String, port: Option<u16>) -> Self {
+    pub fn new(public_key: PublicKey, domain: Option<String>, port: Option<u16>) -> Self {
         Self {
             public_key: public_key.to_base58_check(version_bytes()),
-            domain,
+            domain: domain.unwrap_or(DEFAULT_GRINBOX_DOMAIN.to_string()),
             port,
         }
     }
@@ -218,18 +218,12 @@ impl Address for GrinboxAddress {
 
         let captures = captures.unwrap();
         let public_key = captures.name("public_key").unwrap().as_str().to_string();
-        let domain = captures.name("domain").map(|m| m.as_str().to_string()).unwrap_or(DEFAULT_GRINBOX_DOMAIN.to_string());
+        let domain = captures.name("domain").map(|m| m.as_str().to_string());
         let port = captures.name("port").map(|m| u16::from_str_radix(m.as_str(), 10).unwrap());
 
-        PublicKey::from_base58_check(&public_key, version_bytes())?;
+        let public_key = PublicKey::from_base58_check(&public_key, version_bytes())?;
 
-        let address = Self {
-            public_key,
-            domain,
-            port,
-        };
-
-        Ok(address)
+        Ok(GrinboxAddress::new(public_key, domain, port))
     }
 
     fn address_type(&self) -> AddressType {

--- a/src/contacts/types.rs
+++ b/src/contacts/types.rs
@@ -187,7 +187,7 @@ pub fn version_bytes() -> Vec<u8> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GrinboxAddress {
     pub public_key: String,
     pub domain: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -529,7 +529,8 @@ fn password_prompt(opt: Option<&str>) -> String {
         )
 }
 
-fn proof_ok(address: String, amount: u64, outputs: Vec<String>, kernel: String) {
+fn proof_ok(sender: Option<String>, receiver: String, amount: u64, outputs: Vec<String>, kernel: String) {
+
     println!("this file proves that [{}] received [{}] grins",
              address.bright_green(),
              core::amount_to_hr_string(amount, false).bright_green());
@@ -976,11 +977,11 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
             let w = wallet.lock();
             let tx_proof = w.get_tx_proof(id)?;
             match w.verify_tx_proof(&tx_proof) {
-                Ok((address, amount, outputs, kernel)) => {
+                Ok((sender, receiver, amount, outputs, kernel)) => {
                     let mut file = File::create(input.replace("~", &home_dir))?;
                     file.write_all(serde_json::to_string(&tx_proof)?.as_bytes())?;
                     println!("proof written to {}", input);
-                    proof_ok(address, amount, outputs, kernel);
+                    proof_ok(sender, receiver, amount, outputs, kernel);
                 },
                 Err(_) => {
                     cli_message!("unable to verify proof");
@@ -1001,9 +1002,9 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
 
             let mut wallet = wallet.lock();
             match wallet.verify_tx_proof(&tx_proof) {
-                Ok((address, amount, outputs, kernel)) => {
-                    println!("proof verification succesful!");
-                    proof_ok(address, amount, outputs, kernel);
+                Ok((sender, receiver, amount, outputs, kernel)) => {
+                    println!("proof verification successful!");
+                    proof_ok(sender, receiver, amount, outputs, kernel);
                 },
                 Err(_) => {
                     cli_message!("unable to verify proof");

--- a/src/main.rs
+++ b/src/main.rs
@@ -530,10 +530,14 @@ fn password_prompt(opt: Option<&str>) -> String {
 }
 
 fn proof_ok(sender: Option<String>, receiver: String, amount: u64, outputs: Vec<String>, kernel: String) {
+    let sender_message = sender.map(|s| format!(" from [{}]", s)).unwrap_or(String::new());
 
-    println!("this file proves that [{}] received [{}] grins",
-             address.bright_green(),
-             core::amount_to_hr_string(amount, false).bright_green());
+    println!("this file proves that [{}] grins was sent to [{}]{}",
+        core::amount_to_hr_string(amount, false).bright_green(),
+        receiver.bright_green(),
+        sender_message
+    );
+
     println!("outputs:");
     for output in outputs {
         println!("   {}", output.bright_magenta());

--- a/src/main.rs
+++ b/src/main.rs
@@ -530,7 +530,7 @@ fn password_prompt(opt: Option<&str>) -> String {
 }
 
 fn proof_ok(sender: Option<String>, receiver: String, amount: u64, outputs: Vec<String>, kernel: String) {
-    let sender_message = sender.map(|s| format!(" from [{}]", s)).unwrap_or(String::new());
+    let sender_message = sender.as_ref().map(|s| format!(" from [{}]", s.bright_green())).unwrap_or(String::new());
 
     println!("this file proves that [{}] grins was sent to [{}]{}",
         core::amount_to_hr_string(amount, false).bright_green(),
@@ -538,7 +538,11 @@ fn proof_ok(sender: Option<String>, receiver: String, amount: u64, outputs: Vec<
         sender_message
     );
 
-    println!("outputs:");
+    if sender.is_none() {
+        println!("{}: this proof does not prove which address sent the funds, only which received it", "WARNING".bright_yellow());
+    }
+
+    println!("\noutputs:");
     for output in outputs {
         println!("   {}", output.bright_magenta());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1011,7 +1011,6 @@ fn do_command(command: &str, config: &mut Wallet713Config, wallet: Arc<Mutex<Wal
             let mut wallet = wallet.lock();
             match wallet.verify_tx_proof(&tx_proof) {
                 Ok((sender, receiver, amount, outputs, kernel)) => {
-                    println!("proof verification successful!");
                     proof_ok(sender, receiver, amount, outputs, kernel);
                 },
                 Err(_) => {

--- a/src/wallet/api/api.rs
+++ b/src/wallet/api/api.rs
@@ -393,10 +393,10 @@ impl<W: ?Sized, C, K> Wallet713OwnerAPI<W, C, K>
     pub fn verify_tx_proof(
         &mut self,
         tx_proof: &TxProof,
-    ) -> Result<(GrinboxAddress, u64, Vec<pedersen::Commitment>, PublicKey), Error> {
+    ) -> Result<(Option<GrinboxAddress>, GrinboxAddress, u64, Vec<pedersen::Commitment>, PublicKey), Error> {
         let secp = &Secp256k1::with_caps(ContextFlag::Commit);
 
-        let slate = tx_proof.verify_extract(None)
+        let (destination, slate) = tx_proof.verify_extract(None)
             .map_err(|_| ErrorKind::VerifyProof)?;
 
         let inputs_ex = tx_proof.inputs
@@ -435,7 +435,7 @@ impl<W: ?Sized, C, K> Wallet713OwnerAPI<W, C, K>
             return Err(ErrorKind::VerifyProof.into());
         }
 
-        return Ok((tx_proof.address.clone(), tx_proof.amount, outputs, excess_sum));
+        return Ok((destination, tx_proof.address.clone(), tx_proof.amount, outputs, excess_sum));
     }
 }
 

--- a/src/wallet/api/api.rs
+++ b/src/wallet/api/api.rs
@@ -396,7 +396,7 @@ impl<W: ?Sized, C, K> Wallet713OwnerAPI<W, C, K>
     ) -> Result<(GrinboxAddress, u64, Vec<pedersen::Commitment>, PublicKey), Error> {
         let secp = &Secp256k1::with_caps(ContextFlag::Commit);
 
-        let slate = tx_proof.verify_extract()
+        let slate = tx_proof.verify_extract(None)
             .map_err(|_| ErrorKind::VerifyProof)?;
 
         let inputs_ex = tx_proof.inputs

--- a/src/wallet/types/tx_proof.rs
+++ b/src/wallet/types/tx_proof.rs
@@ -14,6 +14,7 @@ pub enum ErrorKind {
     ParseSignature,
     VerifySignature,
     ParseEncryptedMessage,
+    VerifyDestination,
     DecryptionKey,
     DecryptMessage,
     ParseSlate,
@@ -33,7 +34,7 @@ pub struct TxProof {
 }
 
 impl TxProof {
-    pub fn verify_extract(&self) -> Result<Slate, ErrorKind> {
+    pub fn verify_extract(&self, expected_destination: Option<&GrinboxAddress>) -> Result<Slate, ErrorKind> {
         let mut challenge = String::new();
         challenge.push_str(self.message.as_str());
         challenge.push_str(self.challenge.as_str());
@@ -47,6 +48,11 @@ impl TxProof {
         let encrypted_message: EncryptedMessage = serde_json::from_str(&self.message)
             .map_err(|_| ErrorKind::ParseEncryptedMessage)?;
 
+        // TODO: at some point, make this check required
+        if encrypted_message.destination.is_some() && encrypted_message.destination != expected_destination.map(|a| a.to_string()) {
+            return Err(ErrorKind::VerifyDestination);
+        }
+
         let decrypted_message = encrypted_message.decrypt_with_key(&self.key)
             .map_err(|_| ErrorKind::DecryptMessage)?;
 
@@ -54,7 +60,7 @@ impl TxProof {
             .map_err(|_| ErrorKind::ParseSlate)
     }
 
-    pub fn from_response(from: String, message: String, challenge: String, signature: String, secret_key: &SecretKey) -> Result<(Slate, TxProof), ErrorKind> {
+    pub fn from_response(from: String, message: String, challenge: String, signature: String, secret_key: &SecretKey, expected_destination: Option<&GrinboxAddress>) -> Result<(Slate, TxProof), ErrorKind> {
         let address = GrinboxAddress::from_str(from.as_str())
             .map_err(|_| ErrorKind::ParseAddress)?;
         let signature = Signature::from_hex(signature.as_str())
@@ -64,7 +70,7 @@ impl TxProof {
         let encrypted_message: EncryptedMessage = serde_json::from_str(&message)
             .map_err(|_| ErrorKind::ParseEncryptedMessage)?;
         let key = encrypted_message.key(&public_key, secret_key)
-                .map_err(|_| ErrorKind::DecryptionKey)?;
+            .map_err(|_| ErrorKind::DecryptionKey)?;
 
         let proof = TxProof {
             address,
@@ -78,7 +84,7 @@ impl TxProof {
             outputs: vec![],
         };
 
-        let slate = proof.verify_extract()?;
+        let slate = proof.verify_extract(expected_destination)?;
 
         Ok((slate, proof))
     }

--- a/src/wallet/types/tx_proof.rs
+++ b/src/wallet/types/tx_proof.rs
@@ -50,8 +50,8 @@ impl TxProof {
             .map_err(|_| ErrorKind::ParseEncryptedMessage)?;
 
         // TODO: at some point, make this check required
-        let destination = encrypted_message.destination;
-        if encrypted_message.destination.is_some() && expected_destination.is_some() && destination.as_ref() != expected_destination {
+        let destination = encrypted_message.destination.clone();
+        if destination.is_some() && expected_destination.is_some() && destination.as_ref() != expected_destination {
             return Err(ErrorKind::VerifyDestination);
         }
 

--- a/src/wallet/types/tx_proof.rs
+++ b/src/wallet/types/tx_proof.rs
@@ -3,8 +3,9 @@ use grin_util::secp::Signature;
 use grin_util::secp::key::SecretKey;
 use grin_util::secp::pedersen::Commitment;
 
-use crate::common::crypto::{EncryptedMessage, Hex};
+use crate::common::crypto::Hex;
 use crate::common::crypto::verify_signature;
+use crate::common::message::EncryptedMessage;
 use crate::contacts::{Address, GrinboxAddress};
 
 #[derive(Debug)]
@@ -49,7 +50,7 @@ impl TxProof {
             .map_err(|_| ErrorKind::ParseEncryptedMessage)?;
 
         // TODO: at some point, make this check required
-        if encrypted_message.destination.is_some() && encrypted_message.destination != expected_destination.map(|a| a.to_string()) {
+        if encrypted_message.destination.is_some() && expected_destination.is_some() && encrypted_message.destination.as_ref() != expected_destination {
             return Err(ErrorKind::VerifyDestination);
         }
 

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -288,17 +288,17 @@ impl Wallet {
         api.get_stored_tx_proof(id)
     }
 
-    pub fn verify_tx_proof(&self, tx_proof: &TxProof) -> Result<(String, u64, Vec<String>, String)> {
+    pub fn verify_tx_proof(&self, tx_proof: &TxProof) -> Result<(Option<String>, String, u64, Vec<String>, String)> {
         let wallet = self.get_wallet_instance()?;
         let mut api = Wallet713OwnerAPI::new(wallet.clone());
-        let (address, amount, outputs, excess_sum) = api.verify_tx_proof(tx_proof)?;
+        let (sender, receiver, amount, outputs, excess_sum) = api.verify_tx_proof(tx_proof)?;
 
         let outputs = outputs
             .iter()
             .map(|o| grin_util::to_hex(o.0.to_vec()))
             .collect();
 
-        Ok((address.public_key.clone(), amount, outputs, excess_sum.to_hex()))
+        Ok((sender.map(|a| a.public_key.clone()), receiver.public_key.clone(), amount, outputs, excess_sum.to_hex()))
     }
 
     fn init_seed(&self, wallet_config: &WalletConfig, passphrase: &str) -> Result<WalletSeed> {


### PR DESCRIPTION
This PR adds a destination field to the encrypted message wrapper, which can be used in transaction proofs. At the moment the field is optional, but we could make it mandatory during the first Grin hardfork