### PR TITLE
Improve doc

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -4,7 +4,7 @@ We're really glad that you would like to contribute to wallet713!
 
 When making contributions to this repository, please first discuss the change you wish to make via [issue](https://github.com/vault713/wallet713/issues/new), [gitter](https://gitter.im/vault713/wallet713), [email](mailto:hello@713.mw), or any other method with the owners of this repository before making a change.
 
-Please note we have a [code of conduct](CONTRIBUTING.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 
 ## Work in progress
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,7 +7,7 @@
 * [OpenSSL](https://www.openssl.org).
    * macOS with Homebrew:
       ```
-      $ brew install openssl
+      $ brew install openssl # you need to install version 1.1 of openssl for version 1.0.1 or newer of wallet713
       ``` 
    * Linux:
       ```


### PR DESCRIPTION
Related to https://github.com/vault713/wallet713/issues/128.
I change the setup doc to be more precise. Recent versions of wallet713 need openssl@1.1.