### PR TITLE
Config option: skip invoice fee check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,17 +635,17 @@ dependencies = [
 [[package]]
 name = "grin_api"
 version = "1.0.2"
-source = "git+https://github.com/mimblewimble/grin#fe9fa51f32be9170f257736e403829d8255b9c55"
+source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_core 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_p2p 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_pool 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_chain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_p2p 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_pool 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "1.0.2"
-source = "git+https://github.com/mimblewimble/grin#fe9fa51f32be9170f257736e403829d8255b9c55"
+source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -675,10 +675,10 @@ dependencies = [
  "croaring 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "1.0.2"
-source = "git+https://github.com/mimblewimble/grin#fe9fa51f32be9170f257736e403829d8255b9c55"
+source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -700,8 +700,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,12 +717,12 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "1.0.2"
-source = "git+https://github.com/mimblewimble/grin#fe9fa51f32be9170f257736e403829d8255b9c55"
+source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,15 +739,15 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "1.0.2"
-source = "git+https://github.com/mimblewimble/grin#fe9fa51f32be9170f257736e403829d8255b9c55"
+source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -760,16 +760,16 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "1.0.2"
-source = "git+https://github.com/mimblewimble/grin#fe9fa51f32be9170f257736e403829d8255b9c55"
+source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -793,15 +793,15 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "1.0.2"
-source = "git+https://github.com/mimblewimble/grin#fe9fa51f32be9170f257736e403829d8255b9c55"
+source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "1.0.2"
-source = "git+https://github.com/mimblewimble/grin#fe9fa51f32be9170f257736e403829d8255b9c55"
+source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "grin_wallet"
 version = "1.0.2"
-source = "git+https://github.com/mimblewimble/grin#fe9fa51f32be9170f257736e403829d8255b9c55"
+source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -842,12 +842,12 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_chain 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_core 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_api 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_chain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2530,12 +2530,12 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "gotham 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gotham_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_core 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_keychain 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_store 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)",
- "grin_wallet 1.0.2 (git+https://github.com/mimblewimble/grin)",
+ "grin_api 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_wallet 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2769,16 +2769,16 @@ dependencies = [
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum gotham 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53e97a23641e4e45159e0e585c6cda06d9a47dda8a9b5638aa3cbddad667fb5b"
 "checksum gotham_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c71f93a50b0eec80bf76c525b3840d73fd5f4b056ace0e3566b4eb612336f084"
-"checksum grin_api 1.0.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_chain 1.0.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_core 1.0.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_keychain 1.0.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_p2p 1.0.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_pool 1.0.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_api 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
+"checksum grin_chain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
+"checksum grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
+"checksum grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
+"checksum grin_p2p 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
+"checksum grin_pool 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
 "checksum grin_secp256k1zkp 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "223095ed6108a42855ab2ce368d2056cfd384705f81c494f6d88ab3383161562"
-"checksum grin_store 1.0.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_util 1.0.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
-"checksum grin_wallet 1.0.2 (git+https://github.com/mimblewimble/grin)" = "<none>"
+"checksum grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
+"checksum grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
+"checksum grin_wallet 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"
 "checksum http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,17 +635,17 @@ dependencies = [
 [[package]]
 name = "grin_api"
 version = "1.0.2"
-source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
+source = "git+https://github.com/jaspervdm/grin?branch=patch2#1521f31ff8989f46ae3ca1742d5f61f1bf6db63b"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_chain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_p2p 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_pool 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_chain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_p2p 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_pool 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "grin_chain"
 version = "1.0.2"
-source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
+source = "git+https://github.com/jaspervdm/grin?branch=patch2#1521f31ff8989f46ae3ca1742d5f61f1bf6db63b"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -675,10 +675,10 @@ dependencies = [
  "croaring 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "grin_core"
 version = "1.0.2"
-source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
+source = "git+https://github.com/jaspervdm/grin?branch=patch2#1521f31ff8989f46ae3ca1742d5f61f1bf6db63b"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -700,8 +700,8 @@ dependencies = [
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,12 +717,12 @@ dependencies = [
 [[package]]
 name = "grin_keychain"
 version = "1.0.2"
-source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
+source = "git+https://github.com/jaspervdm/grin?branch=patch2#1521f31ff8989f46ae3ca1742d5f61f1bf6db63b"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,15 +739,15 @@ dependencies = [
 [[package]]
 name = "grin_p2p"
 version = "1.0.2"
-source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
+source = "git+https://github.com/jaspervdm/grin?branch=patch2#1521f31ff8989f46ae3ca1742d5f61f1bf6db63b"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -760,16 +760,16 @@ dependencies = [
 [[package]]
 name = "grin_pool"
 version = "1.0.2"
-source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
+source = "git+https://github.com/jaspervdm/grin?branch=patch2#1521f31ff8989f46ae3ca1742d5f61f1bf6db63b"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -793,15 +793,15 @@ dependencies = [
 [[package]]
 name = "grin_store"
 version = "1.0.2"
-source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
+source = "git+https://github.com/jaspervdm/grin?branch=patch2#1521f31ff8989f46ae3ca1742d5f61f1bf6db63b"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "croaring 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
  "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "grin_util"
 version = "1.0.2"
-source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
+source = "git+https://github.com/jaspervdm/grin?branch=patch2#1521f31ff8989f46ae3ca1742d5f61f1bf6db63b"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -834,7 +834,7 @@ dependencies = [
 [[package]]
 name = "grin_wallet"
 version = "1.0.2"
-source = "git+https://github.com/jaspervdm/grin?branch=patch#0d6b01f069638021e03e44c214badbb1d67f0aa7"
+source = "git+https://github.com/jaspervdm/grin?branch=patch2#1521f31ff8989f46ae3ca1742d5f61f1bf6db63b"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -842,12 +842,12 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_chain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_api 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_chain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2530,12 +2530,12 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "gotham 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gotham_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "grin_api 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
- "grin_wallet 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)",
+ "grin_api 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
+ "grin_wallet 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)",
  "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-zero 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2769,16 +2769,16 @@ dependencies = [
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum gotham 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53e97a23641e4e45159e0e585c6cda06d9a47dda8a9b5638aa3cbddad667fb5b"
 "checksum gotham_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c71f93a50b0eec80bf76c525b3840d73fd5f4b056ace0e3566b4eb612336f084"
-"checksum grin_api 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
-"checksum grin_chain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
-"checksum grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
-"checksum grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
-"checksum grin_p2p 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
-"checksum grin_pool 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
+"checksum grin_api 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)" = "<none>"
+"checksum grin_chain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)" = "<none>"
+"checksum grin_core 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)" = "<none>"
+"checksum grin_keychain 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)" = "<none>"
+"checksum grin_p2p 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)" = "<none>"
+"checksum grin_pool 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)" = "<none>"
 "checksum grin_secp256k1zkp 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "223095ed6108a42855ab2ce368d2056cfd384705f81c494f6d88ab3383161562"
-"checksum grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
-"checksum grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
-"checksum grin_wallet 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch)" = "<none>"
+"checksum grin_store 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)" = "<none>"
+"checksum grin_util 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)" = "<none>"
+"checksum grin_wallet 1.0.2 (git+https://github.com/jaspervdm/grin?branch=patch2)" = "<none>"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"
 "checksum http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ rpassword = "2.1.0"
 url = "1.7"
 parking_lot = {version = "0.6"}
 
-grin_api = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
-grin_core = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
-grin_wallet = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
-grin_keychain = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
-grin_util = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
-grin_store = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
+grin_api = { git = "https://github.com/jaspervdm/grin", branch = "patch2" }
+grin_core = { git = "https://github.com/jaspervdm/grin", branch = "patch2" }
+grin_wallet = { git = "https://github.com/jaspervdm/grin", branch = "patch2" }
+grin_keychain = { git = "https://github.com/jaspervdm/grin", branch = "patch2" }
+grin_util = { git = "https://github.com/jaspervdm/grin", branch = "patch2" }
+grin_store = { git = "https://github.com/jaspervdm/grin", branch = "patch2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ rpassword = "2.1.0"
 url = "1.7"
 parking_lot = {version = "0.6"}
 
-grin_api = { git = "https://github.com/mimblewimble/grin" }
-grin_core = { git = "https://github.com/mimblewimble/grin" }
-grin_wallet = { git = "https://github.com/mimblewimble/grin" }
-grin_keychain = { git = "https://github.com/mimblewimble/grin" }
-grin_util = { git = "https://github.com/mimblewimble/grin" }
-grin_store = { git = "https://github.com/mimblewimble/grin" }
+grin_api = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
+grin_core = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
+grin_wallet = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
+grin_keychain = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
+grin_util = { git = "https://github.com/jaspervdm/grin", branch = "patch" }
+grin_store = { git = "https://github.com/jaspervdm/grin", branch = "patch" }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -40,6 +40,7 @@ pub struct Wallet713Config {
     pub foreign_api: Option<bool>,
     pub foreign_api_address: Option<String>,
     pub foreign_api_secret: Option<String>,
+    pub check_invoice_fee: Option<bool>,
     #[serde(skip)]
     pub config_home: Option<String>,
     #[serde(skip)]
@@ -208,6 +209,10 @@ impl Wallet713Config {
 
     pub fn foreign_api(&self) -> bool {
         self.foreign_api.unwrap_or(false)
+    }
+
+    pub fn check_invoice_fee(&self) -> bool {
+        self.check_invoice_fee.unwrap_or(true)
     }
 }
 

--- a/src/contacts/backend.rs
+++ b/src/contacts/backend.rs
@@ -40,7 +40,7 @@ impl AddressBookBackend for Backend {
     }
 
     fn contacts(&self) -> Box<Iterator<Item = Contact>> {
-        Box::new(self.db.iter(&[CONTACT_PREFIX]).unwrap())
+        Box::new(self.db.iter(&[CONTACT_PREFIX]).unwrap().map(|(_, v)| v))
     }
 
     fn batch<'a>(&'a self) -> Result<Box<AddressBookBatch + 'a>, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,7 +502,7 @@ fn main() {
         .expect("could not create an address book!");
     let address_book = Arc::new(Mutex::new(address_book));
 
-    let wallet = Wallet::new(config.max_auto_accept_invoice);
+    let wallet = Wallet::new(config.max_auto_accept_invoice, config.check_invoice_fee());
     let wallet = Arc::new(Mutex::new(wallet));
 
     let mut grinbox_broker: Option<(GrinboxPublisher, GrinboxSubscriber)> = None;

--- a/src/wallet/backend/lmdb_backend.rs
+++ b/src/wallet/backend/lmdb_backend.rs
@@ -182,7 +182,7 @@ where
     }
 
     fn outputs<'a>(&'a self) -> Box<dyn Iterator<Item = OutputData> + 'a> {
-        Box::new(self.db.iter(&[OUTPUT_PREFIX]).unwrap())
+        Box::new(self.db.iter(&[OUTPUT_PREFIX]).unwrap().map(|(_, v)| v))
     }
 
     fn get_tx_log_by_slate_id(&self, slate_id: &str) -> Result<Option<TxLogEntry>> {
@@ -191,7 +191,7 @@ where
     }
 
     fn tx_logs<'a>(&'a self) -> Box<dyn Iterator<Item = TxLogEntry> + 'a> {
-        Box::new(self.db.iter(&[TX_LOG_ENTRY_PREFIX]).unwrap())
+        Box::new(self.db.iter(&[TX_LOG_ENTRY_PREFIX]).unwrap().map(|(_, v)| v))
     }
 
     fn get_private_context(&mut self, uuid: &str) -> Result<Context> {
@@ -211,7 +211,7 @@ where
     }
 
     fn accounts<'a>(&'a self) -> Box<dyn Iterator<Item = AcctPathMapping> + 'a> {
-        Box::new(self.db.iter(&[ACCOUNT_PATH_MAPPING_PREFIX]).unwrap())
+        Box::new(self.db.iter(&[ACCOUNT_PATH_MAPPING_PREFIX]).unwrap().map(|(_, v)| v))
     }
 
     fn get_acct_path(&self, label: &str) -> Result<AcctPathMapping> {

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -22,14 +22,16 @@ pub struct Wallet {
     active_account: String,
     backend: Option<Arc<Mutex<Backend<HTTPNodeClient, ExtKeychain>>>>,
     max_auto_accept_invoice: Option<u64>,
+    check_invoice_fee: bool,
 }
 
 impl Wallet {
-    pub fn new(max_auto_accept_invoice: Option<u64>) -> Self {
+    pub fn new(max_auto_accept_invoice: Option<u64>, check_invoice_fee: bool) -> Self {
         Self {
             active_account: "default".to_string(),
             backend: None,
             max_auto_accept_invoice,
+            check_invoice_fee,
         }
     }
 
@@ -263,6 +265,9 @@ impl Wallet {
         if slate.amount > max_auto_accept_invoice {
             Err(ErrorKind::InvoiceAmountTooBig(slate.amount))?;
         }
+
+        // Skip fee check for invoices
+        slate.check_fees = self.check_invoice_fee;
 
         let wallet = self.get_wallet_instance()?;
 


### PR DESCRIPTION
This PR allows a new configuration option `check_invoice_fee` that allows to skip checking fees for invoices. This is useful in situations where the invoiced tx is part of a larger tx which will pay for the fee one way or the other.

Waiting for https://github.com/mimblewimble/grin/pull/2651 to be merged in