### PR TITLE
Turn off SSL for Windows

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -120,7 +120,7 @@ impl Wallet713Config {
     }
 
     pub fn grinbox_protocol_unsecure(&self) -> bool {
-        self.grinbox_protocol_unsecure.unwrap_or(false)
+        self.grinbox_protocol_unsecure.unwrap_or(cfg!(windows))
     }
 
     pub fn grinbox_address_index(&self) -> u32 {

--- a/src/contacts/types.rs
+++ b/src/contacts/types.rs
@@ -13,7 +13,10 @@ const ADDRESS_REGEX: &str = r"^((?P<address_type>keybase|grinbox|https)://).+$";
 const GRINBOX_ADDRESS_REGEX: &str = r"^(grinbox://)?(?P<public_key>[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{52})(@(?P<domain>[a-zA-Z0-9\.]+)(:(?P<port>[0-9]*))?)?$";
 const KEYBASE_ADDRESS_REGEX: &str = r"^(keybase://)?(?P<username>[0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_]{1,16})(:(?P<topic>[a-zA-Z0-9_-]+))?$";
 const DEFAULT_GRINBOX_DOMAIN: &str = "grinbox.io";
+#[cfg(not(windows))]
 pub const DEFAULT_GRINBOX_PORT: u16 = 443;
+#[cfg(windows)]
+pub const DEFAULT_GRINBOX_PORT: u16 = 80;
 
 #[derive(PartialEq)]
 pub enum AddressType {


### PR DESCRIPTION
We can't use SSL websocket on Windows until https://github.com/housleyjk/ws-rs/issues/226 is fixed